### PR TITLE
Fix for Org 9

### DIFF
--- a/ob-applescript.el
+++ b/ob-applescript.el
@@ -74,7 +74,7 @@
   (let* ((processed-params (org-babel-process-params params))
          (full-body (org-babel-expand-body:applescript body processed-params)))
     (org-babel-applescript-table-or-string
-     (org-babel-eval "osascript" full-body)
+     (do-applescript full-body)
      params)))
 
 (defun org-babel-execute:apples (body params)

--- a/ob-applescript.el
+++ b/ob-applescript.el
@@ -32,6 +32,7 @@
 ;; language be installed as well.
 
  ;;; Code:
+(require 'seq)
 (require 'ob)
 (require 'ob-core)
 (require 'ob-ref)
@@ -47,11 +48,12 @@
 (defun org-babel-variable-assignments:applescript (params)
   "Return list of AppleScript statements assigning the block's variables."
   (mapcar
-   (lambda (pair)
-     (format "set %s to %s\n"
+   (lambda (param)
+     (let ((pair (cdr param)))
+       (format "set %s to %s\n"
              (car pair)
-             (org-babel-applescript-var-to-applescript (cdr pair))))
-   (mapcar #'cdr (org-babel-get-header params :var))))
+             (org-babel-applescript-var-to-applescript (cdr pair)))))
+   (seq-filter (lambda (param) (eq :var (car param))) params)))
 
 (defun org-babel-applescript-var-to-applescript (var)
   "Convert an elisp var into a string of AppleScript source code

--- a/ob-applescript.el
+++ b/ob-applescript.el
@@ -72,10 +72,10 @@
  This function is called by `org-babel-execute-src-block'"
   (message "executing AppleScript source code block")
   (let* ((processed-params (org-babel-process-params params))
-         (full-body (org-babel-expand-body:applescript body processed-params)))
-    (org-babel-applescript-table-or-string
-     (do-applescript full-body)
-     params)))
+         (full-body (org-babel-expand-body:applescript body processed-params))
+         (result (do-applescript full-body)))
+    (when result
+      (org-babel-applescript-table-or-string result params))))
 
 (defun org-babel-execute:apples (body params)
   "Execute a block of AppleScript with org-babel."

--- a/ob-applescript.el
+++ b/ob-applescript.el
@@ -74,8 +74,7 @@
   (let* ((processed-params (org-babel-process-params params))
          (full-body (org-babel-expand-body:applescript body processed-params))
          (result (do-applescript full-body)))
-    (when result
-      (org-babel-applescript-table-or-string result params))))
+    result))
 
 (defun org-babel-execute:apples (body params)
   "Execute a block of AppleScript with org-babel."


### PR DESCRIPTION
The function `org-babel-get-header` doesn't exist anymore. This replaces the behavior with a simple list manipulation. Feel free to provide an alternative replacement implementation if this isn't good, as I'm an amateur with lisp. 