### PR TITLE
Replace use of org-babel-get-header

### DIFF
--- a/ob-applescript.el
+++ b/ob-applescript.el
@@ -46,12 +46,17 @@
 
 (defun org-babel-variable-assignments:applescript (params)
   "Return list of AppleScript statements assigning the block's variables."
-  (mapcar
-   (lambda (pair)
-     (format "set %s to %s\n"
-             (car pair)
-             (org-babel-applescript-var-to-applescript (cdr pair))))
-   (mapcar #'cdr (org-babel-get-header params :var))))
+  (delq
+   nil
+   (mapcar
+    (lambda (param)
+      (if (eq :var (car param))
+          (let ((pair (cdr param)))
+            (format "set %s to %s\n"
+                    (car pair)
+                    (org-babel-applescript-var-to-applescript (cdr pair))))
+        nil))
+    params)))
 
 (defun org-babel-applescript-var-to-applescript (var)
   "Convert an elisp var into a string of AppleScript source code


### PR DESCRIPTION
org-babel-get-header was removed in Org#0d000f5 (babel: small change in API,
2015-10-29)

I delete org-babel-get-header then implement it from scratch. I've tested it with Org-mode 8.2.10 (Emacs 24.5.1) and Org-mode 9.1.9 (Emacs 26.2.90), both work fine